### PR TITLE
Make instagram image markup dynamic

### DIFF
--- a/content-instagram.php
+++ b/content-instagram.php
@@ -13,6 +13,7 @@
 			</time>
 		</h1>
 		<h2 class="time-stamp"><?php echo how_old_was_zadie(); ?></h2>
+		<?php zah_the_instagram_media(); ?>
 		<?php the_content(); ?>
 
 		<p class="via">(via <a href="<?php echo $post->guid; ?>">@<?php echo get_instagram_username(); ?></a>)</p>

--- a/content-instagram.php
+++ b/content-instagram.php
@@ -1,7 +1,7 @@
 <article class="instagram">
-	
+
 	<?php do_action( 'zah_content_header', $post ); ?>
-	
+
 	<div class="inner">
 		<h1 class="title">
 			<time datetime="<?php echo get_post_time( 'c', true ) ?>">
@@ -14,10 +14,10 @@
 		</h1>
 		<h2 class="time-stamp"><?php echo how_old_was_zadie(); ?></h2>
 		<?php the_content(); ?>
-	
+
 		<p class="via">(via <a href="<?php echo $post->guid; ?>">@<?php echo get_instagram_username(); ?></a>)</p>
 	</div>
-	
+
 	<?php do_action( 'zah_content_footer', $post ); ?>
-	
+
 </article>

--- a/functions.php
+++ b/functions.php
@@ -36,3 +36,4 @@ include 'functions/instagram.php';
 include 'functions/rsvp.php';
 include 'functions/infinite-scroll.php';
 include 'functions/on-this-day.php';
+include 'functions/cli-commands.php';

--- a/functions/cli-commands.php
+++ b/functions/cli-commands.php
@@ -1,0 +1,48 @@
+<?php
+if ( ! class_exists( 'WP_CLI' ) ) {
+	return;
+}
+
+function fix_zadies_instagram_images() {
+	$modified_posts = 0;
+	// Get all Instagram posts
+	$args = array(
+		'posts_per_page' => -1,
+		'post_type' => 'instagram',
+		'post_status' => 'any',
+	);
+	$posts = get_posts( $args );
+	foreach ( $posts as $post ) {
+		$new_post_content = $post->post_content;
+		if ( has_shortcode( $post->post_content, 'video' ) ) {
+			// Get the ID of the Video attachment and store it as post_meta
+			$args = array(
+				'post_type' => 'attachment',
+				'post_parent' => $post->ID,
+				'post_mime_type' => 'video/mp4',
+			);
+			$video_posts = get_posts( $args );
+			foreach ( $video_posts as $video_post ) {
+				update_post_meta( $post->ID, '_video_id', $video_post->ID );
+			}
+		}
+
+		// Strip inline images
+		$new_post_content = preg_replace('/<img(.+) \/>/i', '', $new_post_content );
+
+		// Strip all shortcodes
+		$new_post_content = trim( strip_shortcodes( $new_post_content ) );
+
+		if ( $new_post_content != $post->post_content ) {
+			$new_post = array(
+				'ID' => $post->ID,
+				'post_content' => $new_post_content,
+			);
+			wp_update_post( $new_post );
+			$modified_posts++;
+		}
+	}
+	WP_CLI::line( 'Modified ' . $modified_posts . ' Instagram posts.' );
+	WP_CLI::success( 'Done!' );
+}
+WP_CLI::add_command( 'zah-fix-instagrams', 'fix_zadies_instagram_images' );

--- a/functions/instagram.php
+++ b/functions/instagram.php
@@ -503,6 +503,7 @@ class ZAH_Instagram {
 			return false;
 		}
 
+		$video_id = false;
 		if ( $img->is_video ) {
 			$video_file = $img->video_url;
 			$tmp = download_url( $video_file );

--- a/functions/instagram.php
+++ b/functions/instagram.php
@@ -533,28 +533,15 @@ class ZAH_Instagram {
 			'file_name' => $slug . '.jpg',
 		);
 		$attachment_id = media_sideload_image_return_id( $src, $inserted, $caption, $attachment_data );
-		$img_attr = array(
-			'class' => 'aligncenter from-instagram',
-			'alt' => '',
-		);
-		$updated_post_content = wp_get_attachment_image( $attachment_id, 'full', false, $img_attr ) . "\n\n" . $caption;
-		if ( $img->is_video  ) {
-			$video_src = wp_get_attachment_url( $video_id );
-			$poster = wp_get_attachment_image_src( $attachment_id, 'full' );
-			$updated_post_content = '[video src="' . $video_src . '" poster="' . $poster[0] . '"]' . "\n\n" . $caption;
-		}
-
-		$updated_post = array(
-			'ID' => $inserted,
-			'post_content' => $updated_post_content,
-			'guid' => $permalink,
-		);
-		wp_update_post( $updated_post );
-
 		update_post_meta( $inserted, 'instagram_username', $username );
 
 		// Set the featured image
 		add_post_meta( $inserted, '_thumbnail_id', $attachment_id );
+
+		// If we have a video id, store it as post meta
+		if ( $video_id ) {
+			add_post_meta( $inserted, '_video_id', $video_id );
+		}
 
 		if ( $post['post_status'] != 'publish' ) {
 			// Send an email so we can approve the new photo ASAP!

--- a/functions/instagram.php
+++ b/functions/instagram.php
@@ -524,6 +524,9 @@ class ZAH_Instagram {
 			if ( is_wp_error( $video_id ) ) {
 				@unlink( $file_array['tmp_name'] );
 			}
+
+			// Auto-tag this Instagram post as a video
+			wp_set_object_terms( $inserted, 'video', 'category' );
 		}
 
 		$attachment_data = array(

--- a/functions/media.php
+++ b/functions/media.php
@@ -290,3 +290,34 @@ function zah_svg_icon( $icon = '' ) {
 
 	return '<svg class="icon icon-' . $icon . '" role="img"><use xlink:href="#icon-' . $icon . '"></use></svg>';
 }
+
+function zah_the_instagram_media( $post_id = 0 ) {
+	$post_id = absint( $post_id );
+	if ( ! $post_id ) {
+		$post_id = '';
+	}
+	$post = get_post( $post_id );
+	$featured_image_id = get_post_thumbnail_id( $post->ID );
+	$featured_video_id = get_post_meta( $post->ID, '_video_id', true );
+	if ( $featured_video_id ) {
+		$video_src = wp_get_attachment_url( $featured_video_id );
+		$poster = wp_get_attachment_image_src( $featured_image_id, 'full' );
+		if ( ! empty( $poster[0] ) ) {
+			$poster = $poster[0];
+		}
+		if ( $video_src && $poster ) {
+			$args = array(
+				'src' => $video_src,
+				'poster' => $poster,
+			);
+			echo wp_video_shortcode( $args );
+		return;
+		}
+	}
+
+	$img_attrs = array(
+		'class' => 'aligncenter from-instagram',
+		'alt' => '',
+	);
+	echo wp_get_attachment_image( $featured_image_id, 'full', false, $img_attrs );
+}


### PR DESCRIPTION
 - Strips inline images and `[video]` shortcodes from Instagram posts using a WP CLI command
 - Dynamically add media to Instagram posts via featured image and featured video post meta
 - Automatically categorize video Instagram posts on import

Run using WP CLI: `wp zah-fix-instagrams --url=https://zadieheimlich.com`

Fixes #20